### PR TITLE
readme: fixup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ func main() {
 				Syntax: new(json.Syntax),
 			},
 			// Don't allow to setup "config" flag from file.
-			flagutil.WithIgnoreByName("config"),
+			flagutil.WithStashName("config"),
 		),
 	)
 


### PR DESCRIPTION
There is no `WithIgnoreByName` name in the current master branch, the function was renamed to `WithStashName` in 0d6d4f7d88b250213dbe492036d72773759456eb